### PR TITLE
Use HaltWrappers in List and Map modules (#14737)

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -52,8 +52,9 @@
   into a list is O(1).
 */
 module List {
+  private use ChapelLocks only;
+  private use HaltWrappers;
   private use Sort;
-  private use ChapelLocks only ;
 
   pragma "no doc"
   private const _initialCapacity = 8;
@@ -636,7 +637,7 @@ module List {
 
         if boundsChecking && _size == 0 {
           _leave();
-          halt("Called \"list.first\" on an empty list.");
+          boundsCheckHalt("Called \"list.first\" on an empty list.");
         }
 
         result = _getRef(1);
@@ -667,7 +668,7 @@ module List {
 
         if boundsChecking && _size == 0 {
           _leave();
-          halt("Called \"list.last\" on an empty list.");
+          boundsCheckHalt("Called \"list.last\" on an empty list.");
         }
 
         result = _getRef(_size);
@@ -985,13 +986,14 @@ module List {
       if boundsChecking && _size <= 0 {
         if unlockBeforeHalt then
           _leave();
-        halt("Called \"list.pop\" on an empty list.");
+        boundsCheckHalt("Called \"list.pop\" on an empty list.");
       }
 
       if boundsChecking && !_withinBounds(idx) {
         if unlockBeforeHalt then
           _leave();
-        halt("Index for \"list.pop\" out of bounds: " + idx:string);
+        const msg = "Index for \"list.pop\" out of bounds: " + idx:string;
+        boundsCheckHalt(msg);
       }
 
       ref item = _getRef(idx);
@@ -1161,10 +1163,10 @@ module List {
         const msg = " index for \"list.indexOf\" out of bounds: ";
 
         if end > 0 && !_withinBounds(end) then
-          halt("End" + msg + end:string);
+          boundsCheckHalt("End" + msg + end:string);
 
         if !_withinBounds(start) then
-          halt("Start" + msg + start:string);
+          boundsCheckHalt("Start" + msg + start:string);
       }
 
       param error = -1;
@@ -1276,7 +1278,7 @@ module List {
     proc this(i: int) ref {
       if boundsChecking && !_withinBounds(i) {
         const msg = "Invalid list index: " + i:string;
-        halt(msg);
+        boundsCheckHalt(msg);
       }
 
       ref result = _getRef(i);

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -27,7 +27,8 @@
   mode of its originating map.
 */
 module Map {
-  private use ChapelLocks only ;
+  private use ChapelLocks only;
+  private use HaltWrappers;
 
   // Lock code lifted from modules/standard/Lists.chpl.
   // Maybe they should be combined into a Locks module.
@@ -199,7 +200,7 @@ module Map {
         _leave();
         return result;
       } else {
-        halt("map index out of bounds: ", k);
+        boundsCheckHalt("map index out of bounds: " + k:string);
         ref result = vals._value.data[0];
         _leave();
         return result;
@@ -210,7 +211,7 @@ module Map {
     proc const this(k: keyType) const {
       _enter();
       if !myKeys.contains(k) then
-        halt("map index ", k, " out of bounds");
+        boundsCheckHalt("map index " + k:string + " out of bounds");
       const result = vals[k];
       _leave();
       return result;

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -41,9 +41,9 @@ module Set {
   // Use this to restrict our secondary initializer to only resolve when the
   // "iterable" argument has a method named "these".
   //
-  private use Reflection;
-  private use ChapelLocks only ;
+  private use ChapelLocks only;
   private use IO;
+  private use Reflection;
 
   pragma "no doc"
   private param _sanityChecks = true;


### PR DESCRIPTION
Use HaltWrappers in List and Map modules (#14737)

This PR replaces calls to `halt` in the List and Map modules with
calls to `boundsCheckHalt`, a routine that is part of the HaltWrappers
module. It also sorts the use statements in these modules so that
they are in alphabetical order.

---

Testing:

- [x] ALL on linux64 when CHPL_COMM=none
- [x] ALL on linux64 when CHPL_COMM=gasnet

---

Thanks to @ronawho for signing off on this!